### PR TITLE
fix: sequential thinking

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,6 @@
     "filesystem",
     "logic",
     "memory",
-    "sequential-thinking",
     "time"
   ],
   "permissions": {
@@ -34,7 +33,6 @@
       "mcp__memory__open_nodes",
       "mcp__memory__read_graph",
       "mcp__memory__search_nodes",
-      "mcp__sequential-thinking__sequentialthinking",
       "mcp__time__convert_time",
       "mcp__time__get_current_time",
       "WebFetch(domain:github.com)",


### PR DESCRIPTION
## Objective

Deprecate [`sequential-thinking`](https://github.com/axivo/website/pull/333) MCP server in favour of built-in thinking, present in Opus/Sonnet 4+.

## Scope

- [ ] Bug (resolves an issue)
- [x] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
