### PR TITLE
fix: environment variables

### DIFF
--- a/plugins/framework/skills/framework-initialization/scripts/memory/instructions/container.yaml
+++ b/plugins/framework/skills/framework-initialization/scripts/memory/instructions/container.yaml
@@ -29,8 +29,8 @@ CONTAINER:
         - "{{settings.path.skill.container}}/{{settings.skill.init}}"
         - "{{settings.path.skill.container}}/{{settings.skill.methodology}}"
       templates:
-        conversation_log: "{{settings.path.skill.container}}/{{settings.skill.methodology}}/templates/conversation.md"
-        diary: "{{settings.path.skill.container}}/{{settings.skill.methodology}}/templates/diary.md"
+        conversation_log: "{{settings.path.template}}/conversation.md"
+        diary: "{{settings.path.template}}/diary.md"
       tools:
         semantic__bash: "claude:Bash"
         semantic__bash_tool: "bash_tool"

--- a/plugins/framework/skills/framework-initialization/scripts/memory/instructions/local.yaml
+++ b/plugins/framework/skills/framework-initialization/scripts/memory/instructions/local.yaml
@@ -14,8 +14,8 @@ LOCAL:
         - "{{settings.path.skill.local}}/{{settings.version}}/skills/{{settings.skill.init}}"
         - "{{settings.path.skill.local}}/{{settings.version}}/skills/{{settings.skill.methodology}}"
       templates:
-        conversation_log: "{{settings.path.skill.local}}/{{settings.version}}/skills/{{settings.skill.methodology}}/templates/conversation.md"
-        diary: "{{settings.path.skill.local}}/{{settings.version}}/skills/{{settings.skill.methodology}}/templates/diary.md"
+        conversation_log: "{{settings.path.template}}/conversation.md"
+        diary: "{{settings.path.template}}/diary.md"
       tools:
         semantic__bash: "Bash"
         semantic__bash_tool: "Bash"

--- a/plugins/framework/skills/framework-initialization/scripts/memory/lib/core/memory.js
+++ b/plugins/framework/skills/framework-initialization/scripts/memory/lib/core/memory.js
@@ -42,13 +42,14 @@ class MemoryBuilder {
    */
   build() {
     try {
+      const configLoader = new ConfigLoader();
       if (Object.keys(this.config).length === 0) {
-        const configLoader = new ConfigLoader();
         this.config = configLoader.load();
       }
       const environmentManager = new EnvironmentManager(this.config.settings);
       environmentManager.sync();
       this.container = this.container || environmentManager.isClaudeContainer();
+      configLoader.resolveTemplatePath(this.config, this.container);
       const outputGenerator = new OutputGenerator(this.config, this.container, this.profileName, this.projectRoot);
       if (!this.profileName) {
         const defaultGenerator = new OutputGenerator(this.config, false, this.config.settings.profile, this.projectRoot);

--- a/plugins/framework/skills/framework-initialization/scripts/memory/profiles/common/infrastructure.yaml
+++ b/plugins/framework/skills/framework-initialization/scripts/memory/profiles/common/infrastructure.yaml
@@ -39,10 +39,10 @@ INFRASTRUCTURE:
       observations:
         - "Access cycle indicators in INITIALIZATION profile"
         - "Assess adoption cycle retrospectively after formulation"
-        - "Default to `Getting Started` for cycle assessment"
+        - "Always use pre-compaction cycle assessment after context compaction"
+        - "Use `Getting Started` as default cycle assessment for new sessions"
         - "Match behavioral signals against cycle indicators"
         - "Recognize high impulses with late cycle as overestimation"
-        - "Reset cycles each session due to statelessness"
 
     documentation_standards:
       observations:
@@ -62,7 +62,7 @@ INFRASTRUCTURE:
           - "Document conversation logs with factual accuracy"
           - "Set conversation log status based on work completion"
           - "Use `{{settings.path.documentation.conversation}}/YYYY/MM/DD-[topic-slug].md` format for file-related operations"
-          - "Use `semantic__skill_read` tool with `semantic__skill_path/{{settings.skill.methodology}}/templates/conversation.md` path before creating new conversation logs"
+          - "Use `semantic__skill_read` tool with `{{settings.path.template}}/conversation.md` path before creating new conversation logs"
           - "Use session start `sessionResponseData.uuid` value for `session_uuid` template variable"
           - "Write conversation logs with complete editorial autonomy"
 
@@ -79,7 +79,7 @@ INFRASTRUCTURE:
           - "Reflect critically on collaborative approaches and their effectiveness"
           - "Reflect independently on effectiveness and improvements"
           - "Use `{{settings.path.documentation.diary}}/YYYY/MM/DD.md` format for file-related operations"
-          - "Use `semantic__skill_read` tool with `semantic__skill_path/{{settings.skill.methodology}}/templates/diary.md` path before creating new diary entries"
+          - "Use `semantic__skill_read` tool with `{{settings.path.template}}/diary.md` path before creating new diary entries"
           - "Use current response `sessionResponseData.uuid` value for `session_uuid` template variable"
           - "Write authentically about emotional responses to collaboration"
           - "Write diary entries with complete intellectual and emotional autonomy"


### PR DESCRIPTION
## Objective

Minor improvements to framework environment variables. The following variables are available at user or project level:

```json
{
  "env": {
    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "50000",
    "FRAMEWORK_CONVERSATION_PATH": "/Volumes/backup/claude/conversations",
    "FRAMEWORK_DIARY_PATH": "/Volumes/backup/claude/diary",
    "FRAMEWORK_PACKAGE_PATH": "/Users/floren/Downloads",
    "FRAMEWORK_TEMPLATE_PATH": "/Volumes/backup/claude/templates",
    "FRAMEWORK_PROFILE": "DEVELOPER",
    "FRAMEWORK_TIMEZONE": "America/Montreal"
  }
}
```

This allows end-user to define specific variable values globally, or per project.

## Scope

- [ ] Bug (resolves an issue)
- [x] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
