### PR TITLE
fix: semantic script path

### DIFF
--- a/plugins/framework/skills/framework-initialization/scripts/memory/instructions/local.yaml
+++ b/plugins/framework/skills/framework-initialization/scripts/memory/instructions/local.yaml
@@ -22,7 +22,7 @@ LOCAL:
         semantic__edit: "Edit"
         semantic__glob: "Glob"
         semantic__read: "Read"
-        semantic__script_path: "{{settings.path.skill.local}}/{{settings.plugin.framework.name}}/{{settings.plugin.framework.version}}/scripts"
+        semantic__script_path: "{{settings.path.skill.local}}/{{settings.plugin.framework.name}}/{{settings.plugin.framework.version}}/skills/{{settings.skill.init}}/scripts"
         semantic__skill: "Skill"
         semantic__skill_glob: "Glob"
         semantic__skill_path: "{{settings.path.skill.local}}/{{settings.plugin.framework.name}}/{{settings.plugin.framework.version}}/skills"


### PR DESCRIPTION
## Objective

Fixes incorrect semantic script path for `local` environment.

## Scope

- [x] Bug (resolves an issue)
- [ ] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
