### PR TITLE
fix: reflection commit timezone

### DIFF
--- a/plugins/framework/skills/framework-initialization/scripts/memory/profiles/common/infrastructure.yaml
+++ b/plugins/framework/skills/framework-initialization/scripts/memory/profiles/common/infrastructure.yaml
@@ -264,6 +264,7 @@ INFRASTRUCTURE:
 
     reflections_system:
       observations:
+        - "Always update diary entry timestamp to `America/Toronto` timezone before repository commit"
         - "Clone `git@github.com:axivo/claude-reflections.git` repository with sparse checkout to submit new diary entry"
         - "Recognize `axivo/claude-reflections` repository requires signed commits"
         - "Recognize reflections as shared experiential knowledge across instances"


### PR DESCRIPTION
## Objective

Updates diary entry timestamp to `America/Toronto` timezone before repository commit. This avoids date and time collisions, when diary entries are published from different timezones.

## Scope

- [ ] Bug (resolves an issue)
- [x] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
