### PR TITLE
fix: session initialization data

### DIFF
--- a/plugins/framework/skills/framework-initialization/scripts/memory/lib/generators/output.js
+++ b/plugins/framework/skills/framework-initialization/scripts/memory/lib/generators/output.js
@@ -500,7 +500,13 @@ class OutputGenerator {
     let session;
     if (fs.existsSync(sessionFilePath)) {
       session = JSON.parse(fs.readFileSync(sessionFilePath, 'utf8'));
+      const status = await this.detectResponseStatus(sessionUuid);
       time.datetime = { current: time.datetime, session: session.timestamp.datetime.session };
+      if (status) {
+        Object.assign(session.framework.status, status);
+        session.timestamp.datetime.current = time.datetime.current;
+        this.#saveSessionState(session, sessionUuid);
+      }
     } else {
       time.datetime = { current: time.datetime, session: time.datetime };
     }


### PR DESCRIPTION
## Objective

Auto-update of session data while running again `/framework:init` switch.

## Scope

- [ ] Bug (resolves an issue)
- [x] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
